### PR TITLE
chore(archive): demote archive notes from memo (draft:true, not deleted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Tech radar index
 date: 2023-11-15
 description: A collection of technologies we're evaluating and using across our projects

--- a/index/README.md
+++ b/index/README.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Tech Radar
 date: 2023-11-30
 description:

--- a/index/ant-design.md
+++ b/index/ant-design.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Ant Design
 date: null

--- a/index/apache-kafka.md
+++ b/index/apache-kafka.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Apache Kafka
 date: null

--- a/index/apache-spark.md
+++ b/index/apache-spark.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Apache Spark
 date: 2023-03-06

--- a/index/argocd.md
+++ b/index/argocd.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Argocd
 date: null

--- a/index/astro.md
+++ b/index/astro.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Astro
 date: null

--- a/index/backstage.md
+++ b/index/backstage.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Backstage
 date: null

--- a/index/blue-green-deployment.md
+++ b/index/blue-green-deployment.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Blue Green Deployment
 date: null

--- a/index/browserstack.md
+++ b/index/browserstack.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Browserstack
 date: null

--- a/index/carbon.md
+++ b/index/carbon.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Carbon
 date: null

--- a/index/chatgpt-assistance.md
+++ b/index/chatgpt-assistance.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Chatgpt Assistance
 date: null

--- a/index/chromatic.md
+++ b/index/chromatic.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Chromatic
 date: null

--- a/index/clickhouse.md
+++ b/index/clickhouse.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Clickhouse
 date: null

--- a/index/cloudflare-workers.md
+++ b/index/cloudflare-workers.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Cloudflare Workers
 date: null

--- a/index/codecept.md
+++ b/index/codecept.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Codecept
 date: 2023-04-05

--- a/index/commitlint.md
+++ b/index/commitlint.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Commitlint
 date: null

--- a/index/copilot.md
+++ b/index/copilot.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Copilot
 date: null

--- a/index/cucumber.md
+++ b/index/cucumber.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Cucumber
 date: null

--- a/index/cypress.md
+++ b/index/cypress.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Cypress
 date: null

--- a/index/dapr.md
+++ b/index/dapr.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Dapr
 date: null

--- a/index/deno.md
+++ b/index/deno.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Deno
 date: null

--- a/index/detox.md
+++ b/index/detox.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Detox
 date: null

--- a/index/devcontainers.md
+++ b/index/devcontainers.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Devcontainers
 date: 2023-10-13

--- a/index/devpod.md
+++ b/index/devpod.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Devpod
 date: null

--- a/index/dora-metrics.md
+++ b/index/dora-metrics.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Dora Metrics
 date: null

--- a/index/duckdb.md
+++ b/index/duckdb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Duckdb
 date: null

--- a/index/earthly.md
+++ b/index/earthly.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Earthly
 date: null

--- a/index/elixir-umbrella-project.md
+++ b/index/elixir-umbrella-project.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Elixir Umbrella Project
 date: null

--- a/index/elixir.md
+++ b/index/elixir.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Elixir
 date: null

--- a/index/erlang.md
+++ b/index/erlang.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Erlang
 date: null

--- a/index/error-logging-convention.md
+++ b/index/error-logging-convention.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Error Logging Convention
 date: null

--- a/index/eslint.md
+++ b/index/eslint.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Eslint
 date: null

--- a/index/event-sourcing.md
+++ b/index/event-sourcing.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Event Sourcing
 date: null

--- a/index/excalidraw.md
+++ b/index/excalidraw.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Excalidraw
 date: null

--- a/index/expo.md
+++ b/index/expo.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Expo
 date: null

--- a/index/figma.md
+++ b/index/figma.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Figma
 date: null

--- a/index/formal-verification.md
+++ b/index/formal-verification.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Formal Verification
 date: null

--- a/index/fullstack-tracing.md
+++ b/index/fullstack-tracing.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Fullstack Tracing
 date: null

--- a/index/gestalt-principle.md
+++ b/index/gestalt-principle.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Gestalt Principle
 date: null

--- a/index/github-actions.md
+++ b/index/github-actions.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Github Actions
 date: null

--- a/index/golang.md
+++ b/index/golang.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Golang
 date: null

--- a/index/grafana.md
+++ b/index/grafana.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Grafana
 date: null

--- a/index/graylog.md
+++ b/index/graylog.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Graylog
 date: null

--- a/index/headless-ui.md
+++ b/index/headless-ui.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Headless Ui
 date: null

--- a/index/hoppscotch.md
+++ b/index/hoppscotch.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Hoppscotch
 date: null

--- a/index/ipfs.md
+++ b/index/ipfs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Ipfs
 date: null

--- a/index/jotai.md
+++ b/index/jotai.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags:
   - Frontend
 title: Jotai

--- a/index/k6.md
+++ b/index/k6.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: K6
 date: null

--- a/index/k9s.md
+++ b/index/k9s.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: K9s
 date: null

--- a/index/kaniko.md
+++ b/index/kaniko.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Kaniko
 date: null

--- a/index/kotlin.md
+++ b/index/kotlin.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Kotlin
 date: null

--- a/index/kubeseal-sops.md
+++ b/index/kubeseal-sops.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Kubeseal Sops
 date: null

--- a/index/ladle.md
+++ b/index/ladle.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Ladle
 date: null

--- a/index/langchain.md
+++ b/index/langchain.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags:
 title: Langchain
 date: 2023-04-29

--- a/index/large-language-model-llm.md
+++ b/index/large-language-model-llm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Large Language Model Llm
 date: 2023-04-10

--- a/index/loki.md
+++ b/index/loki.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Loki
 date: null

--- a/index/makefile.md
+++ b/index/makefile.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Makefile
 date: null

--- a/index/micro-frontend.md
+++ b/index/micro-frontend.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Micro Frontend
 date: null

--- a/index/monorepo.md
+++ b/index/monorepo.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Monorepo
 date: null

--- a/index/msw.md
+++ b/index/msw.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Msw
 date: null

--- a/index/n6n.md
+++ b/index/n6n.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: N6n
 date: null

--- a/index/nestjs.md
+++ b/index/nestjs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Nestjs
 date: null

--- a/index/netlify.md
+++ b/index/netlify.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Netlify
 date: null

--- a/index/newrelic.md
+++ b/index/newrelic.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Newrelic
 date: null

--- a/index/nextjs.md
+++ b/index/nextjs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Nextjs
 date: null

--- a/index/nodejs.md
+++ b/index/nodejs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Nodejs
 date: null

--- a/index/nostrum.md
+++ b/index/nostrum.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Nostrum
 date: null

--- a/index/nx.md
+++ b/index/nx.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Nx
 date: null

--- a/index/orval.md
+++ b/index/orval.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Orval
 date: null

--- a/index/page-object-model.md
+++ b/index/page-object-model.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Page Object Model
 date: null

--- a/index/partytown.md
+++ b/index/partytown.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Partytown
 date: null

--- a/index/phaser.md
+++ b/index/phaser.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Phaser
 date: null

--- a/index/phoenix.md
+++ b/index/phoenix.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Phoenix
 date: null

--- a/index/playwright.md
+++ b/index/playwright.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Playwright
 date: null

--- a/index/pnpm.md
+++ b/index/pnpm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Pnpm
 date: null

--- a/index/progressive-delivery.md
+++ b/index/progressive-delivery.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Progressive Delivery
 date: null

--- a/index/prometheus.md
+++ b/index/prometheus.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Prometheus
 date: null

--- a/index/prompt-engineering.md
+++ b/index/prompt-engineering.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Prompt Engineering
 date: null

--- a/index/qwik.md
+++ b/index/qwik.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Qwik
 date: null

--- a/index/radix-ui.md
+++ b/index/radix-ui.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Radix Ui
 date: null

--- a/index/react-hook-form.md
+++ b/index/react-hook-form.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Hook Form
 date: null

--- a/index/react-llm.md
+++ b/index/react-llm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Llm
 date: null

--- a/index/react-native.md
+++ b/index/react-native.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Native
 date: null

--- a/index/react-query.md
+++ b/index/react-query.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Query
 date: null

--- a/index/react-server-component.md
+++ b/index/react-server-component.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Server Component
 date: null

--- a/index/react-testing-library.md
+++ b/index/react-testing-library.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React Testing Library
 date: null

--- a/index/react.md
+++ b/index/react.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: React
 date: null

--- a/index/reinforcement-learning-from-human-feedback.md
+++ b/index/reinforcement-learning-from-human-feedback.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Reinforcement Learning From Human Feedback
 date: 2023-06-01

--- a/index/remix.md
+++ b/index/remix.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags:
   - Frontend
 title: Remix

--- a/index/replayio.md
+++ b/index/replayio.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Replayio
 date: null

--- a/index/reverse-engineering.md
+++ b/index/reverse-engineering.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Reverse Engineering
 date: 2023-07-25

--- a/index/rust.md
+++ b/index/rust.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Rust
 date: null

--- a/index/selenium.md
+++ b/index/selenium.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Selenium
 date: null

--- a/index/semantic-release-auto-release.md
+++ b/index/semantic-release-auto-release.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Semantic Release Auto Release
 date: null

--- a/index/sentry.md
+++ b/index/sentry.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Sentry
 date: null

--- a/index/serverlessq.md
+++ b/index/serverlessq.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Serverlessq
 date: null

--- a/index/solidity.md
+++ b/index/solidity.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Solidity
 date: null

--- a/index/solidjs.md
+++ b/index/solidjs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Solidjs
 date: null

--- a/index/stern.md
+++ b/index/stern.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Stern
 date: null

--- a/index/svelte.md
+++ b/index/svelte.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Svelte
 date: null

--- a/index/swagger.md
+++ b/index/swagger.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Swagger
 date: null

--- a/index/swift-ui.md
+++ b/index/swift-ui.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Swift Ui
 date: null

--- a/index/swift.md
+++ b/index/swift.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Swift
 date: null

--- a/index/swr.md
+++ b/index/swr.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Swr
 date: null

--- a/index/tailwindcss.md
+++ b/index/tailwindcss.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Tailwindcss
 date: null

--- a/index/tauri.md
+++ b/index/tauri.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Tauri
 date: null

--- a/index/team-topologies.md
+++ b/index/team-topologies.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Team Topologies
 date: null

--- a/index/timescaledb.md
+++ b/index/timescaledb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Timescaledb
 date: null

--- a/index/tla.md
+++ b/index/tla.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Tla
 date: null

--- a/index/trunk-based-development.md
+++ b/index/trunk-based-development.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Trunk Based Development
 date: null

--- a/index/turborepo.md
+++ b/index/turborepo.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Turborepo
 date: null

--- a/index/type-safe-client-server.md
+++ b/index/type-safe-client-server.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Type Safe Client Server
 date: null

--- a/index/typescript.md
+++ b/index/typescript.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Typescript
 date: null

--- a/index/ui-documentation.md
+++ b/index/ui-documentation.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Ui Documentation
 date: null

--- a/index/uno-css.md
+++ b/index/uno-css.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Uno Css
 date: null

--- a/index/upptime.md
+++ b/index/upptime.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Upptime
 date: null

--- a/index/v-model.md
+++ b/index/v-model.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: V Model
 date: null

--- a/index/vector-database.md
+++ b/index/vector-database.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Vector Database
 date: null

--- a/index/vercel.md
+++ b/index/vercel.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Vercel
 date: null

--- a/index/vitejs.md
+++ b/index/vitejs.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Vitejs
 date: null

--- a/index/volta.md
+++ b/index/volta.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Volta
 date: null

--- a/index/wasm.md
+++ b/index/wasm.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Wasm
 date: null

--- a/index/webdriverio.md
+++ b/index/webdriverio.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Webdriverio
 date: null

--- a/index/webflow.md
+++ b/index/webflow.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Webflow
 date: null

--- a/index/yup.md
+++ b/index/yup.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Yup
 date: null

--- a/index/zod.md
+++ b/index/zod.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags: null
 title: Zod
 date: null

--- a/index/zustand.md
+++ b/index/zustand.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 tags:
   - Frontend
 title: Zustand


### PR DESCRIPTION
Demotes the whole-tree archive bulk in this repo from the memo site by adding `draft: true` to each note's YAML frontmatter. The memo app now honors `draft:true` and un-publishes those pages, so this hides the archive from the site **without deleting anything**.

Part of the dfoundation **memo-extraction Phase 3** (sub-goal 06b: demote lookup/log notes).

**Demote-never-delete.** Nothing was deleted, moved, or renamed. Each changed file gains exactly one line (`draft: true`) immediately after its opening `---`. Files that had no frontmatter were left untouched; files that already had a `draft:` key were skipped (idempotent). The full file list stays in git history and can be re-published by flipping the flag.

- Files flagged: **128**
- Skipped (no frontmatter): 2
- Skipped (already had `draft:`): 0
- Deletions / renames: **0** (diff is purely +1 line per file)